### PR TITLE
Exclude cmd/json2hcl from Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "cmd/json2hcl"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "cmd/json2hcl"
+  - "cmd/json2hcl/**"


### PR DESCRIPTION
## Summary

Adds `codecov.yml` to exclude the `cmd/json2hcl` CLI entry point from coverage reporting. It's thin glue around the `json2hcl` package and isn't covered by unit tests, so it was dragging the reported coverage down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)