### PR TITLE
Add -n option to skip template escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ brew install winebarrel/json2hcl/json2hcl
 
 ## Usage
 
-```go
+```
 Usage: json2hcl [OPTION] [FILE]
   -n	do not escape ${...} and %{...} template sequences
   -version

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ brew install winebarrel/json2hcl/json2hcl
 
 ```go
 Usage: json2hcl [OPTION] [FILE]
+  -n	do not escape ${...} and %{...} template sequences
   -version
     	print version and exit
 ```

--- a/cmd/json2hcl/flags.go
+++ b/cmd/json2hcl/flags.go
@@ -12,7 +12,8 @@ var (
 )
 
 type flags struct {
-	file string
+	file     string
+	noEscape bool
 }
 
 func init() {
@@ -29,11 +30,14 @@ func init() {
 func parseFlags() *flags {
 	flags := &flags{}
 	showVersion := flag.Bool("version", false, "print version and exit")
+	noEscape := flag.Bool("n", false, "do not escape ${...} and %{...} template sequences")
 	flag.Parse()
 
 	if *showVersion {
 		printVersionAndExit()
 	}
+
+	flags.noEscape = *noEscape
 
 	args := flag.Args()
 

--- a/cmd/json2hcl/main.go
+++ b/cmd/json2hcl/main.go
@@ -31,7 +31,13 @@ func main() {
 		r = bufio.NewReader(f)
 	}
 
-	b, err := json2hcl.UnmarshalFrom(r)
+	var opts []json2hcl.Option
+
+	if flags.noEscape {
+		opts = append(opts, json2hcl.NoEscape())
+	}
+
+	b, err := json2hcl.UnmarshalFrom(r, opts...)
 
 	if err != nil {
 		log.Fatalf("failed to unmarshal JSON: %s", err)

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -11,7 +11,34 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func Unmarshal(b []byte) ([]byte, error) {
+// Option configures Unmarshal and its variants.
+type Option func(*options)
+
+type options struct {
+	escapeTemplates bool
+}
+
+func defaultOptions() options {
+	return options{escapeTemplates: true}
+}
+
+// NoEscape disables escaping of ${...} and %{...} template sequences, emitting
+// the literal characters instead of $${...} / %%{...}. Note this makes those
+// sequences behave as HCL template interpolations/directives rather than
+// literal text.
+func NoEscape() Option {
+	return func(o *options) {
+		o.escapeTemplates = false
+	}
+}
+
+func Unmarshal(b []byte, opts ...Option) ([]byte, error) {
+	o := defaultOptions()
+
+	for _, fn := range opts {
+		fn(&o)
+	}
+
 	dec := json.NewDecoder(bytes.NewReader(b))
 	dec.UseNumber()
 
@@ -30,11 +57,20 @@ func Unmarshal(b []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return bytes.TrimSpace(hclwrite.Format(toks.Bytes())), nil
+	out := bytes.TrimSpace(hclwrite.Format(toks.Bytes()))
+
+	if !o.escapeTemplates {
+		// Undo template-sequence escaping after formatting, so hclwrite.Format
+		// still sees canonical (escaped) input and can't mangle stray '${'.
+		out = bytes.ReplaceAll(out, []byte("$${"), []byte("${"))
+		out = bytes.ReplaceAll(out, []byte("%%{"), []byte("%{"))
+	}
+
+	return out, nil
 }
 
-func UnmarshalString(s string) (string, error) {
-	bs, err := Unmarshal([]byte(s))
+func UnmarshalString(s string, opts ...Option) (string, error) {
+	bs, err := Unmarshal([]byte(s), opts...)
 
 	if err != nil {
 		return "", err
@@ -43,14 +79,14 @@ func UnmarshalString(s string) (string, error) {
 	return string(bs), nil
 }
 
-func UnmarshalFrom(r io.Reader) ([]byte, error) {
+func UnmarshalFrom(r io.Reader, opts ...Option) ([]byte, error) {
 	b, err := io.ReadAll(r)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return Unmarshal(b)
+	return Unmarshal(b, opts...)
 }
 
 // decodeValue reads the next JSON value from dec and converts it into HCL

--- a/unmarshal_noescape_test.go
+++ b/unmarshal_noescape_test.go
@@ -1,0 +1,34 @@
+package json2hcl_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/winebarrel/json2hcl"
+)
+
+func TestUnmarshalNoEscape(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// ${...} and %{...} are emitted literally instead of $${...} / %%{...}
+	s, err := json2hcl.UnmarshalString(`{"foo":"_${bar}_","pct":"%{if x}"}`, json2hcl.NoEscape())
+	require.NoError(err)
+	assert.Equal("{\n  foo = \"_${bar}_\"\n  pct = \"%{if x}\"\n}", s)
+
+	// a stray '${' is not mangled by formatting (no space inserted)
+	s, err = json2hcl.UnmarshalString(`{"a":"${unclosed"}`, json2hcl.NoEscape())
+	require.NoError(err)
+	assert.Equal("{\n  a = \"${unclosed\"\n}", s)
+}
+
+func TestUnmarshalEscapeByDefault(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// without the option, template sequences are escaped
+	s, err := json2hcl.UnmarshalString(`{"foo":"_${bar}_"}`)
+	require.NoError(err)
+	assert.Equal("{\n  foo = \"_$${bar}_\"\n}", s)
+}


### PR DESCRIPTION
## Summary

Adds an opt-in to stop escaping HCL template sequences.

- Library: new `json2hcl.NoEscape()` option on `Unmarshal` / `UnmarshalString` / `UnmarshalFrom` (variadic `...Option`).
- CLI: `-n` flag.

By default `${...}` / `%{...}` are escaped to `$${...}` / `%%{...}` to keep the JSON string value literal. With `-n`, they are emitted verbatim:

```
$ echo '{"foo":"_${bar}_"}' | json2hcl
{
  foo = "_$${bar}_"
}

$ echo '{"foo":"_${bar}_"}' | json2hcl -n
{
  foo = "_${bar}_"
}
```

### Compatibility note

Existing call sites such as `json2hcl.Unmarshal(b)` keep compiling, but the
function *type* changes from `func([]byte) ([]byte, error)` to
`func([]byte, ...Option) ([]byte, error)`, so code that assigns these functions
to a value of the old type would break. Given this is a v0.x, CLI-first tool and
variadic functional options are idiomatic, the variadic approach is kept rather
than adding separate `...WithOptions` variants.

### Implementation note

The un-escaping is a byte replacement (`$${`→`${`, `%%{`→`%{`) applied **after** `hclwrite.Format`. This matters: feeding raw unescaped `${` into `Format` makes it re-lex the string as a template and insert a stray space for an unbalanced `${` (e.g. `"${unclosed"` → `"${unclosed "`). Running the replacement after formatting means `Format` only sees canonical escaped input, so stray `${` is preserved exactly. The 3-byte sequence `$${` only ever appears as the escape of a literal `${` inside string/key content, so the replacement can't hit anything else.

### Caveat

With `-n`, `${...}` becomes an HCL template interpolation rather than literal text, so the output no longer round-trips back to the original string. This is intentional and opt-in.

Coverage stays at 100%; `go vet` / `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)